### PR TITLE
Fix: Spring Boot Gradle Plugin is loaded

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,11 +6,4 @@ pluginManagement {
 		maven { url = uri("https://repo.spring.io/milestone") }
 		gradlePluginPortal()
 	}
-	resolutionStrategy {
-		eachPlugin {
-			if (requested.id.id == "org.springframework.boot") {
-				useModule("org.springframework.boot:spring-boot-gradle-plugin:${requested.version}")
-			}
-		}
-	}
 }


### PR DESCRIPTION
Since the GA version of Spring Boot is now being used (for a while), these lines are preventing the _right_ plugin from being loaded.

The applicable Maven GAV coordinates for the plugin are [`org.springframework.boot:spring.boot.gradle.plugin:2.5.4`](https://repo1.maven.org/maven2/org/springframework/boot/org.springframework.boot.gradle.plugin/2.5.4/) instead of [`org.springframework.boot:spring-boot-gradle-plugin:2.5.4`](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-gradle-plugin/2.5.4/).

Maybe this was added in https://github.com/spring-petclinic/spring-petclinic-kotlin/commit/84d95ab51fd7ed4f22aa0865113bce9316fca36c because [2.2.0.M4](https://repo.spring.io/ui/native/milestone/org/springframework/boot/org.springframework.boot.gradle.plugin/2.2.0.M4) was only available with these [GAV coordinates](https://repo.spring.io/ui/native/milestone/org/springframework/boot/spring-boot-gradle-plugin/2.2.0.M4).
