### PR TITLE
Use WebJars versioned URLs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     kotlin("plugin.spring") version kotlinVersion
 }
 
+// WebJars versions are also referenced in src/main/resources/templates/fragments/layout.html for resource URLs
 val boostrapVersion = "5.1.3"
 val fontAwesomeVersion = "4.7.0"
 
@@ -51,7 +52,6 @@ dependencies {
     implementation("javax.cache:cache-api")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.webjars:webjars-locator-core")
     implementation("org.webjars.npm:bootstrap:$boostrapVersion")
     implementation("org.webjars.npm:font-awesome:$fontAwesomeVersion")
 

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -17,7 +17,7 @@
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
+    <link th:href="@{/webjars/font-awesome/4.7.0/css/font-awesome.min.css}" rel="stylesheet">
     <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
 
 </head>
@@ -87,7 +87,7 @@
     </div>
 </div>
 
-<script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
+<script th:src="@{/webjars/bootstrap/5.1.3/dist/js/bootstrap.bundle.min.js}"></script>
 
 </body>
 


### PR DESCRIPTION
In order to improve efficiency (see spring-projects/spring-framework#27619) and allow native image compatibility, this commit uses WebJars versioned URLs which are supported out of the box on Spring Boot via `/META-INF/resources` default resource location configuration, removing the need to use `webjars-locator-core` dependency and `WebJarsResourceResolver`.

I have been able to measure a consistent 5% startup time improvement on the JVM with that simple change on my local machine.

Similar to https://github.com/spring-projects/spring-petclinic/pull/1099