### PR TITLE
Bump to Spring Boot 3.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,14 +4,14 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 description = "Kotlin version of the Spring Petclinic application"
 group = "org.springframework.samples"
 // Align with Spring Version
-version = "3.1.3"
+version = "3.2.0"
 
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 plugins {
-    val kotlinVersion = "1.8.22"
-    id("org.springframework.boot") version "3.1.3"
-    id("io.spring.dependency-management") version "1.1.0"
+    val kotlinVersion = "1.9.20"
+    id("org.springframework.boot") version "3.2.0"
+    id("io.spring.dependency-management") version "1.1.4"
     id("com.google.cloud.tools.jib") version "3.1.4"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.spring") version kotlinVersion


### PR DESCRIPTION
Spring Boot 3.2.0 available now
https://spring.io/blog/2023/11/23/spring-boot-3-2-0-available-now